### PR TITLE
Add basic i18n.

### DIFF
--- a/Client/Components/GameDialogue.razor
+++ b/Client/Components/GameDialogue.razor
@@ -3,6 +3,7 @@
 @using Melinoe.Shared.Objectives
 @using Melinoe.Shared.Possibilities
 @using Icon = Blazorise.Icons.FontAwesome.Icon
+@using Melinoe.Client.Extensions
 @inherits FluxorComponent
 
 <Container Class="game" Fluid="true">
@@ -56,7 +57,7 @@
             <Column Margin="Margin.Is1" Padding="Padding.Is0" ColumnSize="ColumnSize.IsAuto.OnDesktop.Is3.OnMobile">
                 <Button Block="true" Color="(isEnabled ? Color.Secondary : Color.Dark)" Clicked="() => UpdateObjective(objective, !isEnabled)">
                     <Icon Name="@(isEnabled ? "fa-clipboard-list" : "fa-clipboard-check")" Margin="Margin.Is1.FromRight"  />
-                    @objective
+                    @Localiser.Get(objective)
                 </Button>
             </Column>
         }
@@ -78,7 +79,9 @@
 
                         <TableHeaderCell>
                             <Column Display="Display.Flex.Column">
-                                <Text Alignment="TextAlignment.Center" Color="textColor">@evidence.Type</Text>
+                                <Text Alignment="TextAlignment.Center" Color="textColor">
+                                    @Localiser.Get(evidence.Type)
+                                </Text>
                                 <Field Display="Display.Flex.Row" JustifyContent="JustifyContent.Center" Margin="Margin.Is0">
                                     <Button Size="Size.ExtraSmall" Disabled="@isOverridden" Outline="false" Clicked="() => UpdateEvidence(evidence.Type, EvidenceState.NotPresent)">
                                         <Text Color="iconColor">
@@ -107,7 +110,7 @@
                     Possibility possibility = ghostPossibility.Possibility;
                     <TableRow Background="@(possibility == Possibility.Definite ? Background.Success : Background.Transparent)" TextColor="GetBodyTextColor(possibility)">
                         <TableRowHeader>
-                            @ghostPossibility.Ghost.Name
+                            @Localiser.Get(ghostPossibility.Ghost.Name)
                         </TableRowHeader>
                         @foreach (EvidencePossibility evidence in Game.EvidencePossibilities)
                         {

--- a/Client/Components/GameDialogue.razor.cs
+++ b/Client/Components/GameDialogue.razor.cs
@@ -10,6 +10,7 @@ using Melinoe.Shared.Ghosts;
 using Melinoe.Shared.Objectives;
 using Melinoe.Shared.Possibilities;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace Melinoe.Client.Components
 {
@@ -20,6 +21,9 @@ namespace Melinoe.Client.Components
 
         [Inject]
         public IDispatcher Dispatcher { get; set; }
+        
+        [Inject]
+        public IStringLocalizer<App> Localiser { get; set; }
 
         public GameState Game => State.Value;
 

--- a/Client/Extensions/LocaliserExtensions.cs
+++ b/Client/Extensions/LocaliserExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.Extensions.Localization;
+
+namespace Melinoe.Client.Extensions
+{
+    public static class LocaliserExtensions
+    {
+        public static string Get(this IStringLocalizer localiser, object obj)
+        {
+            if (localiser is null)
+                throw new ArgumentNullException(nameof(localiser));
+
+            if (obj is null)
+                throw new ArgumentNullException(nameof(obj));
+
+            return localiser.GetString(obj.ToString() ?? string.Empty);
+        }
+    }
+}

--- a/Client/Melinoe.Client.csproj
+++ b/Client/Melinoe.Client.csproj
@@ -15,11 +15,22 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.0-preview.1.21103.6" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Shared\Melinoe.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\App.resx">
+      <Generator></Generator>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/Client/Resources/App.resx
+++ b/Client/Resources/App.resx
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Banshee" xml:space="preserve">
+    <value>Banshee</value>
+  </data>
+  <data name="Crucifix" xml:space="preserve">
+    <value>Crucifix</value>
+  </data>
+  <data name="Demon" xml:space="preserve">
+    <value>Demon</value>
+  </data>
+  <data name="EmfLevel5" xml:space="preserve">
+    <value>EMF Level 5</value>
+  </data>
+  <data name="EmfReader" xml:space="preserve">
+    <value>EMF Reader</value>
+  </data>
+  <data name="Fingerprints" xml:space="preserve">
+    <value>Fingerprints</value>
+  </data>
+  <data name="FreezingTemperatures" xml:space="preserve">
+    <value>Freezing Temperatures</value>
+  </data>
+  <data name="GhostEvent" xml:space="preserve">
+    <value>Ghost Event</value>
+  </data>
+  <data name="GhostOrbs" xml:space="preserve">
+    <value>Ghost Orbs</value>
+  </data>
+  <data name="GhostWriting" xml:space="preserve">
+    <value>Ghost Writing</value>
+  </data>
+  <data name="Jinn" xml:space="preserve">
+    <value>Jinn</value>
+  </data>
+  <data name="Mare" xml:space="preserve">
+    <value>Mare</value>
+  </data>
+  <data name="MotionSensor" xml:space="preserve">
+    <value>Motion Sensor</value>
+  </data>
+  <data name="Oni" xml:space="preserve">
+    <value>Oni</value>
+  </data>
+  <data name="Phantom" xml:space="preserve">
+    <value>Phantom</value>
+  </data>
+  <data name="Photo" xml:space="preserve">
+    <value>Photo</value>
+  </data>
+  <data name="Poltergeist" xml:space="preserve">
+    <value>Poltergeist</value>
+  </data>
+  <data name="Revenant" xml:space="preserve">
+    <value>Revenant</value>
+  </data>
+  <data name="Salt" xml:space="preserve">
+    <value>Salt</value>
+  </data>
+  <data name="Shade" xml:space="preserve">
+    <value>Shade</value>
+  </data>
+  <data name="SmudgeArea" xml:space="preserve">
+    <value>Smudge Area</value>
+  </data>
+  <data name="Spirit" xml:space="preserve">
+    <value>Spirit</value>
+  </data>
+  <data name="SpiritBox" xml:space="preserve">
+    <value>Spirit Box</value>
+  </data>
+  <data name="Wraith" xml:space="preserve">
+    <value>Wraith</value>
+  </data>
+  <data name="Yurei" xml:space="preserve">
+    <value>Yurei</value>
+  </data>
+</root>

--- a/Client/Startup.cs
+++ b/Client/Startup.cs
@@ -55,6 +55,8 @@ namespace Melinoe.Client
 
             services.AddBlazoredToast();
             services.AddBlazoredLocalStorage();
+
+            services.AddLocalization(options => options.ResourcesPath = "Resources");
         }
 
         public void Configure(WebAssemblyHost host)

--- a/Client/_Imports.razor
+++ b/Client/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
+@using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
 @using Blazored.Toast
 @using Blazored.Toast.Services


### PR DESCRIPTION
Currently only translates code-names (e.g. `EmfLevel5`) to their English-counterparts.